### PR TITLE
Handle missing Docker in cluster IP lookup

### DIFF
--- a/cluster/local/cluster_ips.py
+++ b/cluster/local/cluster_ips.py
@@ -1,19 +1,38 @@
 import subprocess
 import json
-from typing import List
+from typing import List, Tuple
 
 
-def get_local_container_ips() -> List[str]:
-    """Get IP addresses of running Factorio containers in the local Docker setup."""
-    # Get container IDs for factorio containers
+def get_local_container_ips() -> Tuple[List[str], List[int], List[int]]:
+    """Return IP addresses and ports of running Factorio Docker containers.
+
+    Returns
+    -------
+    Tuple[List[str], List[int], List[int]]
+        A tuple containing lists of IP addresses, UDP ports and TCP ports.
+        If Docker is not available or no containers are running, the lists
+        will all be empty.
+    """
+
+    # Get container IDs for Factorio containers
     cmd = ['docker', 'ps', '--filter', 'name=factorio_', '--format', '"{{.ID}}"']
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        # Docker binary not found in PATH
+        print("Docker executable not found. Is Docker installed?")
+        return [], [], []
+    except subprocess.CalledProcessError:
+        # `docker ps` failed for some reason
+        print("Failed to query Docker for running containers")
+        return [], [], []
+
     container_ids = result.stdout.strip().split('\n')
-    container_ids = [id.strip('"') for id in container_ids]
+    container_ids = [cid.strip('"') for cid in container_ids]
 
     if not container_ids or container_ids[0] == '':
         print("No running Factorio containers found")
-        return []
+        return [], [], []
 
     ips = []
     udp_ports = []

--- a/cluster/tests/test_cluster_ips.py
+++ b/cluster/tests/test_cluster_ips.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the Python path so ``cluster`` can be imported
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from cluster.local.cluster_ips import get_local_container_ips
+
+
+def test_get_local_container_ips_handles_missing_docker(monkeypatch):
+    """If Docker is not installed, function should return empty lists."""
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ips, udp_ports, tcp_ports = get_local_container_ips()
+    assert ips == []
+    assert udp_ports == []
+    assert tcp_ports == []
+


### PR DESCRIPTION
## Summary
- Improve cluster IP discovery by returning empty lists when Docker is unavailable or no containers are running
- Correct return type and add error handling in `get_local_container_ips`
- Add unit test verifying behavior when Docker is missing

## Testing
- `pytest cluster/tests/test_cluster_ips.py -q`
- `pytest env/tests/test_eval.py::test_math -q` *(fails: RCONConnectError: Failed to establish a connection to the server)*

------
https://chatgpt.com/codex/tasks/task_e_688e8c5a85148333af533f6a96772b31