### PR TITLE
Add Lua conversion error test

### DIFF
--- a/tests/test_rcon_utils.py
+++ b/tests/test_rcon_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from fle.env.utils.rcon import _lua2python
+from fle.env.utils.rcon import (
+    LuaConversionError,
+    _check_output_for_errors,
+    _lua2python,
+)
 
 
 @pytest.fixture()
@@ -15,3 +19,11 @@ def test_lua_2_python():
     response, timing = _lua2python(command, lua_response)
 
     assert response == {"a": False, "b": "string global", 2: "]"}
+    assert timing >= 0
+
+
+def test_lua2python_error():
+    error_output = "Unexpected end of string while parsing Lua string."
+
+    with pytest.raises(LuaConversionError):
+        _check_output_for_errors("cmd", "resp", error_output)


### PR DESCRIPTION
## Summary
- test Lua error detection via `_check_output_for_errors`
- assert non-negative timing in `_lua2python` tests

## Testing
- `pytest tests/test_rcon_utils.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_688e8db3d55083338b47953d95af2f14